### PR TITLE
Update jenkins parent to 2.20, remove obsolete properties overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.2</version>
+    <version>2.20</version>
   </parent>
 
   <artifactId>hello-world</artifactId>
@@ -89,10 +89,5 @@
       <url>gitsite:git@github.com/jenkinsci/hello-world-plugin</url>
     </site>
   </distributionManagement>
-
-  <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
-  </properties>
 
 </project>


### PR DESCRIPTION
I was going through the tutorial, and had problems with JAR compatibility using maven. Hopefully this fixes it for the next person. 